### PR TITLE
corrected check on offset and num params for naming the result df, fix #28

### DIFF
--- a/extract_faces.py
+++ b/extract_faces.py
@@ -140,8 +140,8 @@ def main():
         print('Saving videos DataFrame to {}'.format(videodataset_path))
         df_videos.to_pickle(str(videodataset_path))
 
-        if offset is not None:
-            if num is not None:
+        if offset > 0:
+            if num > 0:
                 if facesdataset_path.is_dir():
                     facesdataset_path = facesdataset_path.joinpath(
                         'faces_df_from_video_{}_to_video_{}.pkl'.format(offset, num + offset))
@@ -155,13 +155,16 @@ def main():
                 else:
                     facesdataset_path = facesdataset_path.parent.joinpath(
                         str(facesdataset_path.parts[-1]).split('.')[0] + '_from_video_{}.pkl'.format(offset))
-        elif num is not None:
+        elif num > 0:
             if facesdataset_path.is_dir():
                 facesdataset_path = facesdataset_path.joinpath(
                     'faces_df_from_video_{}_to_video_{}.pkl'.format(0, num))
             else:
                 facesdataset_path = facesdataset_path.parent.joinpath(
                     str(facesdataset_path.parts[-1]).split('.')[0] + '_from_video_{}_to_video_{}.pkl'.format(0, num))
+        else:
+            if facesdataset_path.is_dir():
+                facesdataset_path = facesdataset_path.joinpath('faces_df.pkl')  # just a check if the path is a dir
 
         # Creates directory (if doesn't exist)
         facesdataset_path.parent.mkdir(parents=True, exist_ok=True)

--- a/test_model.py
+++ b/test_model.py
@@ -173,7 +173,7 @@ def main():
     out_folder.mkdir(mode=0o775, parents=True, exist_ok=True)
 
     # Samples selection
-    if max_num_videos_per_label is not None:
+    if max_num_videos_per_label > 0:
         dfs_out_train = [select_videos(df, max_num_videos_per_label) for df in train_dfs]
         dfs_out_val = [select_videos(df, max_num_videos_per_label) for df in val_dfs]
         dfs_out_test = [select_videos(df, max_num_videos_per_label) for df in test_dfs]


### PR DESCRIPTION
Tests:

 - [x] run with --offset;
 -  [x] run with --num;
 -  [x] run with --num and --offset;
 -  [x] run without --num and --offset (w/ --collateonly) to see if the name is correctly saved when we are processing the entire dataset and not just a --num of videos w/ a starting --offset