### PR TITLE
made num_video a required argument

### DIFF
--- a/test_model.py
+++ b/test_model.py
@@ -76,7 +76,7 @@ def main():
     parser.add_argument('--models_dir', type=Path, help='Folder with trained models',
                         default='weights/')
 
-    parser.add_argument('--num_video', type=int, help='Number of real-fake videos to test',required=True)
+    parser.add_argument('--num_video', type=int, help='Number of real-fake videos to test')
     parser.add_argument('--results_dir', type=Path, help='Output folder',
                         default='results/')
 
@@ -173,7 +173,7 @@ def main():
     out_folder.mkdir(mode=0o775, parents=True, exist_ok=True)
 
     # Samples selection
-    if max_num_videos_per_label > 0:
+    if max_num_videos_per_label and max_num_videos_per_label > 0:
         dfs_out_train = [select_videos(df, max_num_videos_per_label) for df in train_dfs]
         dfs_out_val = [select_videos(df, max_num_videos_per_label) for df in val_dfs]
         dfs_out_test = [select_videos(df, max_num_videos_per_label) for df in test_dfs]

--- a/test_model.py
+++ b/test_model.py
@@ -76,7 +76,7 @@ def main():
     parser.add_argument('--models_dir', type=Path, help='Folder with trained models',
                         default='weights/')
 
-    parser.add_argument('--num_video', type=int, help='Number of real-fake videos to test')
+    parser.add_argument('--num_video', type=int, help='Number of real-fake videos to test',required=True)
     parser.add_argument('--results_dir', type=Path, help='Output folder',
                         default='results/')
 


### PR DESCRIPTION
Hey,

I think the `num_video` argument in test_model.py must be mandatory(required=True).

If we run it without the num_video argument using:
`python3 test_model.py --model_path weights/binclass/net-EfficientNetB4ST_traindb-ff-c23-720-140-140_face-scale_size-224_seed-0/bestval.pth --testsets ff-c23-720-140-140 --ffpp_faces_df_path facesdf/faces_df.pkl --ffpp_faces_dir faces/ `

We get the following error at [line 176](https://github.com/polimi-ispl/icpr2020dfdc/blob/7c4b417897957032bb801e902fa56536481ec6a7/test_model.py#L176)
TypeError: '>' not supported between instances of 'NoneType' and 'int'

By specifying `num_video` argument while running test_model.py, the issue is solved.

Thank you