### PR TITLE
preserve 'original' and 'test' columns when extracting face, fix #40

### DIFF
--- a/extract_faces.py
+++ b/extract_faces.py
@@ -186,7 +186,8 @@ def main(argv):
         df_faces['videosubject'] = df_faces['videosubject'].astype(np.int8)
         # Eventually remove duplicates
         df_faces = df_faces.loc[~df_faces.index.duplicated(keep='first')]
-        fields_to_preserve_from_video = [i for i in ['folder', 'subject', 'scene', 'cluster', 'nfaces'] if
+        fields_to_preserve_from_video = [i for i in
+                                         ['folder', 'subject', 'scene', 'cluster', 'nfaces', 'original', 'test'] if
                                          i in df_videos]
         df_faces = pd.merge(df_faces, df_videos[fields_to_preserve_from_video], left_on='video',
                             right_index=True)

--- a/test/test_dfdc.py
+++ b/test/test_dfdc.py
@@ -65,4 +65,4 @@ class TestDFDC(unittest.TestCase):
                                   .glob('*.jpg'))), 5)
 
         faces_df = pd.read_pickle(faces_df_path)
-        self.assertEqual(faces_df.shape, (30, 23))
+        self.assertEqual(faces_df.shape, (30, 24))

--- a/test/test_ffpp.py
+++ b/test/test_ffpp.py
@@ -93,4 +93,4 @@ class TestFFPP(unittest.TestCase):
                                   .glob('*.jpg'))), 5)
 
         faces_df = pd.read_pickle(faces_df_path)
-        self.assertEqual(faces_df.shape, (50, 25))
+        self.assertEqual(faces_df.shape, (50, 26))


### PR DESCRIPTION
This should not affect dfdc and ffpp while allowing the correct handling of celeb. 
